### PR TITLE
[Controller] Websocket support

### DIFF
--- a/src/controller/handler/agent.go
+++ b/src/controller/handler/agent.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+    "fmt"
+    "golang.org/x/net/websocket"
+    "github.com/gorilla/mux"
+)
+
+func WsWrapper(h func (*websocket.Conn)) websocket.Handler {
+    return websocket.Handler(h)
+}
+
+func AgentHandler(ws *websocket.Conn) {
+    userKey := mux.Vars(ws.Request())["user_key"]
+    fmt.Println(userKey)
+    // TODO agent operations
+
+    /*
+    e.g. echo message
+    msg := make([]byte, 512)
+    n, err := ws.Read(msg)
+    if err != nil {
+    	log.Fatal(err)
+    }
+    fmt.Printf("Receive: %s\n", msg[:n])
+
+    m, err := ws.Write(msg[:n])
+    if err != nil {
+    	log.Fatal(err)
+    }
+    fmt.Printf("Send: %s\n", msg[:m])
+    */
+}


### PR DESCRIPTION
- adjust Route type to handle more case
  - HandlerFunc => Handler
  - http.HandlerFunc => interface{}
  - use Route.Handler.(http.HandlerFunc)
      Route.Handler.(http.Handler)
- add agent.go in handler
  - add golang.org/x/net for import websocket
  - add AgentHandler and WsWrapper
